### PR TITLE
Fix typing and documentation for Ads create

### DIFF
--- a/docs/markdown/pinterest.ads.md
+++ b/docs/markdown/pinterest.ads.md
@@ -414,7 +414,7 @@ Bases: `PinterestBaseModel`
 Ad model used to view, create, update its attributes
 
 
-#### _classmethod_ create(ad_account_id: str, ad_group_id, creative_type: str, pin_id: str, is_pin_deleted: bool = False, is_removable: bool = True, status: str = 'ACTIVE', android_deep_link: ~typing.Optional[str] = None, carousel_android_deep_links: ~typing.Optional[list[str]] = None, carousel_destination_urls: ~typing.Optional[list[str]] = None, carousel_ios_deep_links: ~typing.Optional[list[str]] = None, click_tracking_url: ~typing.Optional[str] = None, destination_url: ~typing.Optional[str] = None, ios_deep_link: ~typing.Optional[str] = None, name: ~typing.Optional[str] = None, tracking_urls: ~typing.Optional[dict] = None, view_tracking_url: ~typing.Optional[str] = None, client: ~pinterest.client.PinterestSDKClient = <pinterest.client.PinterestSDKClient object>, \*\*kwargs)
+#### _classmethod_ create(ad_account_id: str, ad_group_id: str, creative_type: str, pin_id: str, is_pin_deleted: bool = False, is_removable: bool = True, status: str = 'ACTIVE', android_deep_link: ~typing.Optional[str] = None, carousel_android_deep_links: ~typing.Optional[list[str]] = None, carousel_destination_urls: ~typing.Optional[list[str]] = None, carousel_ios_deep_links: ~typing.Optional[list[str]] = None, click_tracking_url: ~typing.Optional[str] = None, destination_url: ~typing.Optional[str] = None, ios_deep_link: ~typing.Optional[str] = None, name: ~typing.Optional[str] = None, tracking_urls: ~typing.Optional[dict] = None, view_tracking_url: ~typing.Optional[str] = None, client: ~pinterest.client.PinterestSDKClient = <pinterest.client.PinterestSDKClient object>, \*\*kwargs)
 Create a new ad. Request must contain ad_group_id, creative_type, and the source Pin pin_id.
 
 
@@ -424,7 +424,7 @@ Create a new ad. Request must contain ad_group_id, creative_type, and the source
     * **ad_account_id** (*str*) – Campaign’s Ad Account ID.
 
 
-    * **ad_group_id** (*_type_*) – ID of the ad group that contains the ad.
+    * **ad_group_id** (*str*) – ID of the ad group that contains the ad.
 
 
     * **creative_type** (*str*) – Ad creative type enum. Enum: “REGULAR” “VIDEO” “SHOPPING”

--- a/pinterest/ads/ads.py
+++ b/pinterest/ads/ads.py
@@ -51,7 +51,7 @@ class Ad(PinterestBaseModel):
     @classmethod
     def create(cls,
                ad_account_id:str,
-               ad_group_id,
+               ad_group_id:str,
                creative_type:str,
                pin_id:str,
                is_pin_deleted:bool = False,
@@ -76,7 +76,7 @@ class Ad(PinterestBaseModel):
 
         Args:
             ad_account_id (str): Campaign's Ad Account ID.
-            ad_group_id (_type_): ID of the ad group that contains the ad.
+            ad_group_id (str): ID of the ad group that contains the ad.
             creative_type (str): Ad creative type enum. Enum: `"REGULAR"` `"VIDEO"` `"SHOPPING"`
                         `"CAROUSEL"` `"MAX_VIDEO"` `"SHOP_THE_PIN"` `"IDEA"`
             pin_id (str): ID of the pin used to make the ad.
@@ -111,7 +111,7 @@ class Ad(PinterestBaseModel):
             client (PinterestSDKClient, optional): PinterestSDKClient Object. Defaults to default_api_client.
 
         Returns:
-            Ad: _description_
+            Ad: Ad Object.
         """
         # pylint: disable=too-many-arguments
 
@@ -121,10 +121,10 @@ class Ad(PinterestBaseModel):
         api_response = AdsApi(client).ads_create(
             ad_account_id=str(ad_account_id),
             ad_create_request=[AdCreateRequest(
-                ad_account_id=ad_account_id,
-                ad_group_id=ad_group_id,
+                ad_account_id=str(ad_account_id),
+                ad_group_id=str(ad_group_id),
                 creative_type=creative_type,
-                pin_id=pin_id,
+                pin_id=str(pin_id),
                 status=status,
                 is_pin_deleted=is_pin_deleted,
                 is_removable=is_removable,


### PR DESCRIPTION
- Add typing for `_id` arguments in Ads create() class method
- Make relevant change to markdown documentation