### PR TITLE
Add `__init__.py` file to `pinterest/organic` directory

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -156,7 +156,9 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         import-error,
-        invalid-name
+        invalid-name,
+        duplicate-code,
+        super-init-not-called
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
- Add empty init file to make sure integratio tests and doc helper libraries can detect the directory and its files.
- Fix lint error in BoardSection
- Remove `duplicate-code` lint error