### PR TITLE
Bug Fix: Logic for getting all pages in `_list()` method of `BaseModel`

### DIFF
--- a/pinterest/utils/base_model.py
+++ b/pinterest/utils/base_model.py
@@ -132,28 +132,21 @@ class PinterestBaseModel:
         items = []
         bookmark = None
 
-        # Python do while, always execute at least 1
-        while True:
-            http_response = cls._call_method(
-                cls._get_api_instance(api, client),
-                list_fn.__name__,
-                params,
-                **kwargs
-            )
+        http_response = cls._call_method(
+            cls._get_api_instance(api, client),
+            list_fn.__name__,
+            params,
+            **kwargs
+        )
 
-            verify_api_response(http_response)
+        verify_api_response(http_response)
 
-            items = http_response.get('items', [])
-            bookmark = http_response.get('bookmark', None)
-            # Only execute 1 if page size is set
-            if page_size is not None:
-                break
-            # Set the new bookmark
-            if bookmark is not None:
-                kwargs["bookmark"] = bookmark
-            # if bookmark is none this mean all items is extracted.
-            else:
-                break
+        items = http_response.get('items', [])
+        bookmark = http_response.get('bookmark', None)
+
+        # Set the new bookmark
+        if bookmark is not None:
+            kwargs["bookmark"] = bookmark
 
         kwargs.update(params)
         bookmark_model = Bookmark(


### PR DESCRIPTION
Calling `<entity>.get_all()` would return a list of entities and a Bookmark model that returns a new `entity_list` on each `Bookmark.get_next()` call which performs API calls only when necessary to fetch a new set, and eventually returns all entities for the parent.