### PR TITLE
Bug Fix: Pass constructor client to `PinterestBaseModel` init

### DIFF
--- a/pinterest/ads/ads.py
+++ b/pinterest/ads/ads.py
@@ -70,6 +70,7 @@ class Ad(PinterestBaseModel):
             generated_api_get_fn="ads_get",
             generated_api_get_fn_args={"ad_account_id": ad_account_id, "ad_id": ad_id},
             model_attribute_types = AdResponse.openapi_types,
+            client=client,
         )
         self._ad_account_id = str(ad_account_id)
         self._populate_fields(**kwargs)


### PR DESCRIPTION
As a result of the `PinterestBaseModel.__init__` getting called without the passed in client from the `Ad` model constructor, the requests failed resulting in an Auth error. This PR should fix the problem.