### PR TITLE
Fix: Add PHONY target for integration_tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: integration_tests
+
 install:
 	@echo pip install
 	pip install -r requirements.txt


### PR DESCRIPTION
As integration_tests was a folder too, a PHONY target needed to be added for the makefile target.