### PR TITLE
Feature fixes for differences between SDK Models and Server Code + latest spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ target/
 
 # Config files
 .env
+http_logs.txt

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: integration_tests lint unit_tests
+
 install:
 	@echo pip install
 	pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,10 @@ package_test:
 	./package_test/run.sh
 
 integration_tests:
+	@echo cleaning organic data...
+	python -m pytest ./integration_tests/clean_organic_data.py
 	@echo integration tests...
-	python -m pytest --cov ./pinterest/ --cov-branch ./integration_tests/ --cov-report term-missing
+	python -m pytest --ignore=clean_organic_data.py --cov ./pinterest/ --cov-branch ./integration_tests/ --cov-report term-missing
 
 clean: clean-build clean-pyc ## Clean
 

--- a/integration_tests/ads/test_ad_groups.py
+++ b/integration_tests/ads/test_ad_groups.py
@@ -23,6 +23,8 @@ class TestCreateAdGroup(BaseTestCase):
             campaign_id=getattr(self.ad_group_utils.campaign, "_id"),
             billable_event="IMPRESSION",
             name="SDK_INTEGRATION_TEST_ADGROUP",
+            auto_targeting_enabled=False,
+            bid_in_micro_currency=10000000,
         )
 
         assert ad_group
@@ -136,6 +138,8 @@ class TestGetListAdGroup(BaseTestCase):
             campaign_id=getattr(new_campaign, "_id"),
             billable_event="IMPRESSION",
             name="SDK_INTEGRATION_TEST_ADGROUP",
+            auto_targeting_enabled=False,
+            bid_in_micro_currency=10000000,
         )
 
         new_ad_groups = AdGroup.get_all(

--- a/integration_tests/ads/test_campaigns.py
+++ b/integration_tests/ads/test_campaigns.py
@@ -30,7 +30,7 @@ class TestCreateCampaign(BaseTestCase):
             ad_account_id=DEFAULT_AD_ACCOUNT_ID,
             name="SDK Test Campaign",
             objective_type="AWARENESS",
-            daily_spend_cap=10,
+            daily_spend_cap=10000000,
         )
 
         assert campaign
@@ -52,7 +52,7 @@ class TestCreateCampaign(BaseTestCase):
 
         self.assertRaisesRegex(
             SdkException,
-            r"^[\S\s]*campaigns should have a campaign level budget[\S\s]*$",
+            r"^[\S\s]*code 2384[\S\s]*$",
             Campaign.create,
             **campaign_arguments)
 
@@ -65,7 +65,7 @@ class TestCreateCampaign(BaseTestCase):
             ad_account_id=DEFAULT_AD_ACCOUNT_ID,
             name="SDK Test Campaign",
             objective_type="INCORRECT_OBJECTIVE_TYPE",
-            daily_spend_cap=10,
+            daily_spend_cap=10000000,
         )
         with self.assertRaisesRegex(ApiValueError, "Invalid"):
             Campaign.create(**campaign_arguments)
@@ -184,6 +184,8 @@ class TestGetAllCampaigns(BaseTestCase):
                     campaign_id=getattr(campaign, '_id'),
                     billable_event="IMPRESSION",
                     name="SDK_INTEGRATION_TEST_ADGROUP",
+                    auto_targeting_enabled=False,
+                    bid_in_micro_currency=10000000,
                 )
             )
 

--- a/integration_tests/ads/test_conversion_events.py
+++ b/integration_tests/ads/test_conversion_events.py
@@ -23,6 +23,8 @@ class TestSendConversionEvent(BaseTestCase):
         raw_user_data = dict(
             em = ["964bbaf162703657e787eb4455197c8b35c18940c75980b0285619fe9b8acec8"] #random hash256
         )
+        raw_custom_data = dict()
+
         conversion_events = [
             Conversion.create_conversion_event(
                 event_name = "add_to_cart",
@@ -30,6 +32,7 @@ class TestSendConversionEvent(BaseTestCase):
                 event_time = 1670026573,
                 event_id = "eventId0001",
                 user_data = raw_user_data,
+                custom_data= raw_custom_data,
             )
             for _ in range(NUMBER_OF_CONVERSION_EVENTS)
         ]
@@ -64,6 +67,8 @@ class TestSendConversionEvent(BaseTestCase):
         raw_user_data = dict(
             em = ["test_non_hashed_email@pinterest.com"]
         )
+        raw_custom_data = dict()
+
         conversion_events = [
             Conversion.create_conversion_event(
                 event_name = "add_to_cart",
@@ -71,6 +76,7 @@ class TestSendConversionEvent(BaseTestCase):
                 event_time = 1670026573,
                 event_id = "eventId0001",
                 user_data = raw_user_data,
+                custom_data = raw_custom_data,
             )
             for _ in range(NUMBER_OF_CONVERSION_EVENTS)
         ]
@@ -87,5 +93,5 @@ class TestSendConversionEvent(BaseTestCase):
         assert response.num_events_processed == 2
         assert len(response.events) == 2
 
-        assert response.events[0].warning_message == "'em' is not in sha256 hashed format."
-        assert response.events[1].warning_message == "'em' is not in sha256 hashed format."
+        assert response.events[0].warning_message #warning returned
+        assert response.events[1].warning_message #warning returned

--- a/integration_tests/ads/test_conversion_tags.py
+++ b/integration_tests/ads/test_conversion_tags.py
@@ -97,6 +97,10 @@ class TestGetListConversionTag(BaseTestCase):
         conversion_tags = ConversionTag.get_all(ad_account_id = ad_account_id)
 
         assert len(conversion_tags) == NUMBER_OF_NEW_CONVERSION_TAG
+        for conversion_tag in conversion_tags:
+            assert conversion_tag.name == "SDK_TEST_CONVERSION_TAG"
+            assert conversion_tag.ad_account_id == ad_account_id
+
 
 class TestGetPageVsitConversionTag(BaseTestCase):
     """

--- a/integration_tests/clean_organic_data.py
+++ b/integration_tests/clean_organic_data.py
@@ -1,0 +1,18 @@
+"""
+Delete all non-essential organic data from test user
+"""
+
+from pinterest.organic.boards import Board
+from integration_tests.config import DEFAULT_BOARD_ID
+
+def test_delete_organic_data():
+    """
+    Delete organic boards from default client
+    """
+    all_boards, _ = Board.get_all()
+    for board in all_boards:
+        if board.id == DEFAULT_BOARD_ID:
+            continue
+        Board.delete(board_id=board.id)
+
+    assert len(Board.get_all()[0]) == 1

--- a/integration_tests/organic/test_boards.py
+++ b/integration_tests/organic/test_boards.py
@@ -17,6 +17,7 @@ from pinterest.organic.pins import Pin
 from integration_tests.base_test import BaseTestCase
 from integration_tests.config import DEFAULT_BOARD_ID, DEFAULT_BOARD_NAME
 
+
 class TestGetBoard(BaseTestCase):
     """
     Test intializing Board model
@@ -56,15 +57,16 @@ class TestCreateAndDeleteBoard(BaseTestCase):
         """
         Test creating a new Board and deleting the Board successfully
         """
+        random_board_name = self.board_utils.get_random_board_name()
         board = Board.create(
-            name="SDK Test Create Board",
+            name=random_board_name,
             description="SDK Test Board Description",
             privacy="PUBLIC",
             client=self.test_client
         )
 
         assert board
-        assert board.name == "SDK Test Create Board"
+        assert board.name == random_board_name
 
         self.board_utils.delete_board(board_id=board.id)
 
@@ -88,7 +90,8 @@ class TestBoardUpdateFields(BaseTestCase):
 
         board = self.board_utils.create_new_board(
             description=old_description,
-            privacy=old_privacy
+            privacy=old_privacy,
+            name=self.board_utils.get_random_board_name()
         )
 
         assert board.description == old_description
@@ -107,7 +110,7 @@ class TestBoardUpdateFields(BaseTestCase):
         """
         Test updating the name of the board with invalid/existing board name value.
         """
-        board = self.board_utils.create_new_board()
+        board = self.board_utils.create_new_board(name=self.board_utils.get_random_board_name())
 
         assert board
 
@@ -135,7 +138,7 @@ class TestChangeBoardPrivacy(BaseTestCase):
         and
         Test making a public board secret successfully
         """
-        board = self.board_utils.create_new_board(privacy=old_privacy)
+        board = self.board_utils.create_new_board(privacy=old_privacy, name=self.board_utils.get_random_board_name())
 
         assert board
         assert board.privacy == old_privacy
@@ -154,7 +157,8 @@ class TestBoardSectionOperations(BaseTestCase):
         """
         Test creating a new board section under a board model successfully.
         """
-        board = self.board_utils.create_new_board(name="Create Board Section Test")
+        random_board_name = self.board_utils.get_random_board_name()
+        board = self.board_utils.create_new_board(name=random_board_name)
 
         assert board
 
@@ -282,41 +286,35 @@ class TestListPinsOnBoardAndBoardSection(BaseTestCase):
         """
         Test if all pins on a board are returned
         """
-        new_board = self.board_utils.create_new_board(name="GET ALL BOARD PINS TEST BOARD")
+        new_board = self.board_utils.create_new_board(name=self.board_utils.get_random_board_name())
 
         NUMBER_OF_PINS_TO_CREATE = 3
 
         PIN_CREATION_MEDIA_SOURCES = [
             {
-                "source_type": "image_url",
+                "source_type": "image_base64",
                 "content_type": "image/jpeg",
-                "data": "string",
-                'url':'https://i.pinimg.com/564x/28/75/e9/2875e94f8055227e72d514b837adb271.jpg'
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABNUlEQVR4nOzRQQkAIADAQBH7fwXrWcQY93CXYLB17h5xpg74XQOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrAPYCAAD//2UYAxd4/Gr3AAAAAElFTkSuQmCC",
             },
             {
-                "source_type": "image_url",
+                "source_type": "image_base64",
                 "content_type": "image/jpeg",
-                "data": "string",
-                'url':'https://i.picsum.photos/id/13/2500/1667.jpg?hmac=SoX9UoHhN8HyklRA4A3vcCWJMVtiBXUg0W4ljWTor7s'
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABVElEQVR4nOzTQQ3CQABEUdgQziQoQgYeuGCiYiqnOiqiIvbw0vQ/BZP8zGN5/m9ntv7eesKUoQdcXQGwAmAFwAqAFQArAFYArABYAbACYAXACoAVACsAVgCsAFgBsAJgBcAKgBUAKwBWAKwAWAGwAmAFwAqAFQArAFYArABYAbACYAXACoAVACsAVgCsAFgBsAJgBcAKgBUAKwBWAKwAWAGwAmAFwAqAFQArAFYArABYAbACYAXACoAVACsAdt/HR2+Y8n1tesKUHoAVACsAVgCsAFgBsAJgBcAKgBUAKwBWAKwAWAGwAmAFwAqAFQArAFYArABYAbACYAXACoAVACsAVgCsAFgBsAJgBcAKgBUAKwBWAKwAWAGwAmAFwAqAFQArAFYArABYAbACYAXACoAVACsAVgCsAFgBsAJgBcAKgBUAKwBWAKwAWAGwAmBHAAAA//8nhwWSfghzXAAAAABJRU5ErkJggg==",
             },
             {
-                "source_type": "image_url",
+                "source_type": "image_base64",
                 "content_type": "image/jpeg",
-                "data": "string",
-                'url':'https://i.picsum.photos/id/21/3008/2008.jpg?hmac=T8DSVNvP-QldCew7WD4jj_S3mWwxZPqdF0CNPksSko4'
-            }
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABpklEQVR4nOzbQSrtcRiH8XtvZwm3W3esFFZgZAfGRgbMbYAlUIyUPSg5SilCtiA7MFcytgSjt2fy+Szg+zv1nHf4X6x+PvyatHa7N7r/trUc3f+7fTi6/2d0nR8JEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFii7vLp9EHPk6+RveXV7O///3gfHTfBcQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmACx30fr/2Zf2H0enf9//TK6/7oz+/2BC4gJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFii5XNjdEHjk/vR/cvzvZH928eZ/+jLiAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASIfQcAAP//pBwaLoqp/uUAAAAASUVORK5CYII=",
+            },
         ]
-
-        created_pin_ids = set(
-            getattr(self.pin_utils.create_new_pin(
+        created_pin_ids = set()
+        for num in range(NUMBER_OF_PINS_TO_CREATE):
+            response = self.pin_utils.create_new_pin(
                 board_id=new_board.id,
                 title=f"GET ALL PINS TEST #{num}",
                 media_source=PIN_CREATION_MEDIA_SOURCES[num]
-                ),
-                'id'
             )
-            for num in range(NUMBER_OF_PINS_TO_CREATE)
-        )
+            created_pin_ids.add(getattr(response, 'id'))
 
         assert len(created_pin_ids) == NUMBER_OF_PINS_TO_CREATE
 
@@ -325,6 +323,7 @@ class TestListPinsOnBoardAndBoardSection(BaseTestCase):
         # delete organic data from prod
         for pin in pins_list:
             self.pin_utils.delete_pin(pin.id)
+
         self.board_utils.delete_board(new_board.id)
 
         assert len(created_pin_ids) == len(pins_list)
@@ -340,29 +339,27 @@ class TestListPinsOnBoardAndBoardSection(BaseTestCase):
         """
         Test if all pins on a board section are returned
         """
-        new_board = self.board_utils.create_new_board(name="GET ALL BOARD SECTION PINS TEST BOARD")
+        random_board_name = self.board_utils.get_random_board_name()
+        new_board = self.board_utils.create_new_board(name=random_board_name)
         new_section = new_board.create_section(name="GET ALL PINS FROM BOARD SECTION Test")
 
         NUMBER_OF_PINS_TO_CREATE = 3
         PIN_CREATION_MEDIA_SOURCES = [
             {
-                "source_type": "image_url",
+                "source_type": "image_base64",
                 "content_type": "image/jpeg",
-                "data": "string",
-                'url':'https://i.pinimg.com/564x/28/75/e9/2875e94f8055227e72d514b837adb271.jpg'
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABqUlEQVR4nOzToUodABSH8d3tro6FPcTWlsfC2oXVpTUxit1kk1vEIJh8CDGaDbeaxGASxCAWswg+gunwld/vAf4nfJzl3tebD5Ounv6P7n/+sxrdP99sRvc/jq7zLgFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQGxxe/lz9MDx2cHo/sP37dH9w/WX0X0fEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQWPz5djx74tXs0un+3+ja6f3r/OLrvA2ICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATIDYcv33dfTAv4vn0f393y+j+ztbJ6P7PiAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASIvQUAAP//k50aDw7OHnwAAAAASUVORK5CYII=",
             },
             {
-                "source_type": "image_url",
+                "source_type": "image_base64",
                 "content_type": "image/jpeg",
-                "data": "string",
-                'url':'https://i.picsum.photos/id/13/2500/1667.jpg?hmac=SoX9UoHhN8HyklRA4A3vcCWJMVtiBXUg0W4ljWTor7s'
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABq0lEQVR4nOzTL0oeABjH8W28abywlfUxxmAs7ASewWAQxQPYrJb3CCYxyJsEkwfwT7BZPYHRJmYFk0cwPXzL53OA3xO+PIuHn38+Tbp/+ze6f748Hd1/XP0d3f8yus6HBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAscW3/5ujB7ZOtkf3fxzvjO5ffF2P7vuAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATIPb58HZj9MD+3cHo/mr9Orp/9nQ0uu8DYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgNhib3k5euDl183o/u7vq9H95+vvo/s+ICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIi9BwAA//9BBBgTPEF1UQAAAABJRU5ErkJggg==",
             },
             {
-                "source_type": "image_url",
+                "source_type": "image_base64",
                 "content_type": "image/jpeg",
-                "data": "string",
-                'url':'https://i.picsum.photos/id/21/3008/2008.jpg?hmac=T8DSVNvP-QldCew7WD4jj_S3mWwxZPqdF0CNPksSko4'
-            }
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABq0lEQVR4nOzbvUndYRiH4RD+AySEhHwMcFJlghQiWAq2ioU4weGAvQO4goUgVlaOYGtlq9ZWLnA6R7B6uJvrGuD3FjdP+S5/Lp8/TTpfbUf3D672Rvdvfu2M7n8eXedDAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyA2HL35XT0gfX+yej+78P16P7j6t/ovguICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYsvZ3/+jDzy9bUb3jzcXo/s/vx6N7ruAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATILbs3t6PPvBwvR3d//5t9n/Dy+uP0X0XEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsTeAwAA//8vexX9K+3GIgAAAABJRU5ErkJggg==",
+            },
         ]
 
         created_pin_ids = set(

--- a/integration_tests/organic/test_boards.py
+++ b/integration_tests/organic/test_boards.py
@@ -33,8 +33,8 @@ class TestGetBoard(BaseTestCase):
 
         assert board
         assert board.id == DEFAULT_BOARD_ID
-        assert board.name == DEFAULT_BOARD_NAME
-
+        self.assertIsNotNone(board.name)
+        self.assertIsNotNone(board.description)
     def test_get_board_failure_invalid_board_id(self):
         """
         Test getting a Board failure due to invalid board id

--- a/integration_tests/organic/test_pins.py
+++ b/integration_tests/organic/test_pins.py
@@ -12,6 +12,7 @@ from pinterest.organic.pins import Pin
 from integration_tests.base_test import BaseTestCase
 from integration_tests.config import DEFAULT_PIN_ID
 from integration_tests.config import DEFAULT_BOARD_ID
+from integration_tests.config import DEFAULT_AD_ACCOUNT_ID
 from integration_tests.config import DEFAULT_BOARD_SECTION_ID
 
 class TestGetPin(BaseTestCase):
@@ -23,12 +24,12 @@ class TestGetPin(BaseTestCase):
             ({
                 'description': 'PIN is PUBLIC',
                 'pin_id': DEFAULT_PIN_ID,
-                'ad_account_id': None,
+                'ad_account_id': DEFAULT_AD_ACCOUNT_ID,
             },),
             ({
                 'description': 'PIN in PROTECTED BOARD',
                 'pin_id': DEFAULT_PIN_ID,
-                'ad_account_id': None,
+                'ad_account_id': DEFAULT_AD_ACCOUNT_ID,
             },)
         ]
     )
@@ -62,6 +63,7 @@ class TestCreateAndDeletePin(BaseTestCase):
                 "data": "string",
                 'url':'https://i.pinimg.com/564x/28/75/e9/2875e94f8055227e72d514b837adb271.jpg'
                 },
+            ad_account_id = DEFAULT_AD_ACCOUNT_ID,
             client=self.test_client
         )
 

--- a/integration_tests/utils/ads_utils.py
+++ b/integration_tests/utils/ads_utils.py
@@ -108,7 +108,7 @@ class CampaignUtils:
             ad_account_id=DEFAULT_AD_ACCOUNT_ID,
             name="SDK Test Campaign",
             objective_type="AWARENESS",
-            daily_spend_cap=10,
+            daily_spend_cap=10000000,
         )
         self.campaign_id = self.campaign._id
 
@@ -124,7 +124,7 @@ class CampaignUtils:
             ad_account_id=DEFAULT_AD_ACCOUNT_ID,
             name="SDK Test Campaign",
             objective_type="AWARENESS",
-            daily_spend_cap=10,
+            daily_spend_cap=10000000,
         )
 
     def create_new_campaign(self, **kwargs):

--- a/integration_tests/utils/ads_utils.py
+++ b/integration_tests/utils/ads_utils.py
@@ -142,6 +142,8 @@ class AdGroupUtils:
             billable_event="IMPRESSION",
             client=self.test_client,
             name="SDK_INTEGRATION_TEST_ADGROUP",
+            auto_targeting_enabled=False,
+            bid_in_micro_currency=10000000,
         )
         self.ad_group_id = self.ad_group._id
 
@@ -158,6 +160,8 @@ class AdGroupUtils:
             billable_event="IMPRESSION",
             client=self.test_client,
             name="SDK_INTEGRATION_TEST_ADGROUP",
+            auto_targeting_enabled=False,
+            bid_in_micro_currency=10000000,
         )
 
     def create_new_ad_group(self, **kwargs):

--- a/integration_tests/utils/organic_utils.py
+++ b/integration_tests/utils/organic_utils.py
@@ -1,8 +1,7 @@
 """
 Provide helper and utility functions for Organic Endpoints Integration Testing
 """
-from openapi_generated.pinterest_client.api.boards_api import BoardsApi
-from openapi_generated.pinterest_client.model.board import Board as GeneratedBoard
+import random
 
 from pinterest.client import PinterestSDKClient
 
@@ -26,6 +25,9 @@ class BoardUtils:
     def __init__(self, client=None):
         self.test_client = client or PinterestSDKClient.create_default_client()
         self.board = Board(board_id=DEFAULT_BOARD_ID, client=client)
+
+    def get_random_board_name(self):
+        return "SDK Test Create Board {}".format(random.randint(0, 1000))
 
     def get_board(self):
         return self.board

--- a/pinterest/ads/ad_accounts.py
+++ b/pinterest/ads/ad_accounts.py
@@ -44,6 +44,8 @@ class AdAccount(PinterestBaseModel):
         self._country = None
         self._currency = None
         self._permissions = None
+        self._created_time = None
+        self._updated_time = None
 
         PinterestBaseModel.__init__(
             self,
@@ -85,6 +87,16 @@ class AdAccount(PinterestBaseModel):
     def permissions(self) -> list[str]:
         # pylint: disable=missing-function-docstring
         return self._permissions
+
+    @property
+    def created_time(self) -> int:
+        # pylint: disable=missing-function-docstring
+        return self._created_time
+
+    @property
+    def updated_time(self) -> int:
+        # pylint: disable=missing-function-docstring
+        return self._updated_time
 
     @classmethod
     def create(

--- a/pinterest/ads/ad_groups.py
+++ b/pinterest/ads/ad_groups.py
@@ -63,6 +63,7 @@ class AdGroup(PinterestBaseModel):
         self._summary_status = None
         self._feed_profile_id = None
         self._dca_assets = None
+        self._optimization_goal_metadata = None
 
         PinterestBaseModel.__init__(
             self,
@@ -200,6 +201,11 @@ class AdGroup(PinterestBaseModel):
     def dca_assets(self):
         #pylint: disable=missing-function-docstring
         return self._dca_assets
+
+    @property
+    def optimization_goal_metadata(self):
+        #pylint: disable=missing-function-docstring
+        return self._optimization_goal_metadata
 
 
     @classmethod

--- a/pinterest/ads/campaigns.py
+++ b/pinterest/ads/campaigns.py
@@ -55,6 +55,7 @@ class Campaign(PinterestBaseModel):
         self._type = None
         self._is_flexible_daily_budgets = None
         self._is_campaign_budget_optimization = None
+        self._summary_status = None
 
         PinterestBaseModel.__init__(
             self,
@@ -147,6 +148,11 @@ class Campaign(PinterestBaseModel):
     def is_campaign_budget_optimization(self) -> bool:
         # pylint: disable=missing-function-docstring
         return self._is_campaign_budget_optimization
+
+    @property
+    def summary_status(self) -> str:
+        # pylint: disable=missing-function-docstring
+        return self._summary_status
 
 
     @classmethod

--- a/pinterest/ads/conversion_events.py
+++ b/pinterest/ads/conversion_events.py
@@ -3,11 +3,12 @@ Conversion Event Class for Pinterest Python SDK
 """
 from __future__ import annotations
 
-from openapi_generated.pinterest_client.api.conversion_events_api import ConversionEventsApi
 from openapi_generated.pinterest_client.model.conversion_events import ConversionEvents
+from openapi_generated.pinterest_client.api.conversion_events_api import ConversionEventsApi
 from openapi_generated.pinterest_client.model.conversion_events_data import ConversionEventsData
-from openapi_generated.pinterest_client.model.conversion_api_response_events import ConversionApiResponseEvents
 from openapi_generated.pinterest_client.model.conversion_events_user_data import ConversionEventsUserData
+from openapi_generated.pinterest_client.model.conversion_events_custom_data import ConversionEventsCustomData
+from openapi_generated.pinterest_client.model.conversion_api_response_events import ConversionApiResponseEvents
 
 from pinterest.client import PinterestSDKClient
 from pinterest.utils.base_model import PinterestBaseModel
@@ -26,6 +27,7 @@ class Conversion(PinterestBaseModel):
         event_time : int,
         event_id : str,
         user_data : dict,
+        custom_data : dict,
         event_source_url : str = None,
         partner_name : str = None,
         app_id : str = None,
@@ -39,7 +41,7 @@ class Conversion(PinterestBaseModel):
         language : str = None,
         **kwargs
     ) -> ConversionEventsData:
-        """ Create Conversion Event Data to be sent
+        """ Create Conversion Event Data to be sent.
 
         Args:
             event_name (str): The type of the user event, Enum: "add_to_cart", "checkout", "custom",
@@ -51,6 +53,7 @@ class Conversion(PinterestBaseModel):
                 between events ingested via both the conversion API and Pinterest tracking
             user_data (dict): Object containing customer information data. Note, it is required at least
                 one of 1) em, 2) hashed_maids or 3) pair client_ip_address + client_user_agent.
+            custom_data (dict): Object containing other custom data.
             event_source_url (str, optional): URL of the web conversion event
             partner_name (str, optional): The third party partner name responsible to send the event to
                 Conversion API on behalf of the adverstiser. Only send this field if Pinterest has worked
@@ -74,6 +77,7 @@ class Conversion(PinterestBaseModel):
             event_time = event_time,
             event_id = event_id,
             user_data = ConversionEventsUserData(**user_data),
+            custom_data = ConversionEventsCustomData(**custom_data),
             event_source_url = event_source_url,
             partner_name = partner_name,
             app_id = app_id,
@@ -98,12 +102,11 @@ class Conversion(PinterestBaseModel):
         **kwargs,
     )-> tuple(int, int, list[ConversionApiResponseEvents]):
         """
-        Send conversion events to Pinterest API for Conversions
+        Send conversion events to Pinterest API for Conversions.
 
-        Note: Highly recommend to use create_client_with_token (with Conversion Access Token) to create new client
-        for this functionality.
+        Note: Highly recommend to use create_client_with_token (with Conversion Access Token) to create different
+        client for this functionality.
         """
-
         response = ConversionEventsApi(api_client=cls._get_client(client)).events_create(
             ad_account_id = str(ad_account_id),
             conversion_events = ConversionEvents(

--- a/pinterest/ads/conversion_tags.py
+++ b/pinterest/ads/conversion_tags.py
@@ -30,7 +30,7 @@ class ConversionTag(PinterestBaseModel):
         **kwargs
     ) -> None:
         """
-        Initialize Conversion Tag Object
+        Initialize Conversion Tag Object.
 
         Args:
             ad_account_id (str): ConversionTag's Ad Account ID
@@ -208,14 +208,14 @@ class ConversionTag(PinterestBaseModel):
         Get a list of ConversionTag, filter by specified arguments
 
         Args:
-            ad_account_id (str): _description_
-            filter_deleted (bool, optional): _description_. Defaults to False.
-            client (_type_, optional): _description_. Defaults to PinterestSDKClient=None.
+            ad_account_id (str): Unique identifier of an ad account.
+            filter_deleted (bool=False, optional): Filter out deleted tags.
+            client (_type_, optional): PinterestSDKClient Object. Uses the default client, if not provided.
 
         Returns:
             list[ConversionTag]: List of ConversionTags
         """
-        params = {"ad_account_id" : ad_account_id, "filter_deleted": filter_deleted}
+        params = {"ad_account_id" : str(ad_account_id), "filter_deleted": filter_deleted}
 
         def _map_function(obj):
             return ConversionTag(
@@ -245,7 +245,7 @@ class ConversionTag(PinterestBaseModel):
         **kwargs
     ) -> tuple[list[ConversionEventResponse], Bookmark]:
         """
-        Get page visit conversion tag events for an ad account
+        Get page visit conversion tag events for an ad account.
 
         Args:
             ad_account (str): Ad Account ID
@@ -284,7 +284,7 @@ class ConversionTag(PinterestBaseModel):
         **kwargs
     ) -> tuple[str, list[ConversionEventResponse]]:
         """
-        Get OCPM eligible conversion tag events for an Ad Account
+        Get OCPM eligible conversion tag events for an Ad Account.
 
         Args:
             ad_account_id (str): Ad Account ID

--- a/pinterest/organic/pins.py
+++ b/pinterest/organic/pins.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from openapi_generated.pinterest_client.api.pins_api import PinsApi
 from openapi_generated.pinterest_client.model.pin import Pin as GeneratedPin
+from openapi_generated.pinterest_client.model.pin_create import PinCreate as GeneratedPinCreate
 from openapi_generated.pinterest_client.model.inline_object import InlineObject
 
 from pinterest.client import PinterestSDKClient
@@ -202,7 +203,7 @@ class Pin(PinterestBaseModel):
             client = cls._get_client()
 
         api_response = PinsApi(client).pins_create(
-            pin=GeneratedPin(
+            pin_create=GeneratedPinCreate(
                 link=link,
                 title=title,
                 description=description,

--- a/pinterest/organic/pins.py
+++ b/pinterest/organic/pins.py
@@ -141,16 +141,16 @@ class Pin(PinterestBaseModel):
     @classmethod
     def create(
         cls,
-        board_id:str,
-        media_source:dict,
-        link:str = None,
-        title:str = None,
-        description:str = None,
-        dominant_color:str = None,
-        alt_text:str = None,
-        board_section_id:str = None,
-        parent_pin_id:str = None,
-        client:PinterestSDKClient = None,
+        board_id : str,
+        media_source : dict,
+        link : str = None,
+        title : str = None,
+        description : str = None,
+        dominant_color : str = None,
+        alt_text : str = None,
+        board_section_id : str = None,
+        parent_pin_id : str = None,
+        client : PinterestSDKClient = None,
         **kwargs
     ) -> Pin:
         """
@@ -213,8 +213,8 @@ class Pin(PinterestBaseModel):
                 board_section_id=board_section_id,
                 media_source=media_source,
                 parent_pin_id=parent_pin_id,
-                **kwargs,
-            )
+            ),
+            **kwargs,
         )  # pylint: disable=no-value-for-parameter
         verify_api_response(api_response)
 

--- a/tests/src/pinterest/ads/test_conversion_events.py
+++ b/tests/src/pinterest/ads/test_conversion_events.py
@@ -1,10 +1,8 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-
 from openapi_generated.pinterest_client.model.conversion_api_response import ConversionApiResponse
 from openapi_generated.pinterest_client.model.conversion_api_response_events import ConversionApiResponseEvents
-
 
 from pinterest.ads.conversion_events import Conversion
 
@@ -46,6 +44,7 @@ class TestConversionEvent(TestCase):
                 event_time = 1670026573,
                 event_id = "eventId0001",
                 user_data = raw_user_data,
+                custom_data = dict(),
             )
             for _ in range(NUMBER_OF_CONVERSION_EVENTS)
         ]

--- a/tests/src/pinterest/ads/test_conversion_tags.py
+++ b/tests/src/pinterest/ads/test_conversion_tags.py
@@ -159,33 +159,57 @@ class TestConversionTagCreate(TestCase):
                     enhanced_match_status = EnhancedMatchStatusType("VALIDATION_COMPLETE"),
                     id = self.test_conversion_tag_id,
                     last_fired_time_ms = float(1599030000000),
-                    name = "ACME Checkout Test Tag",
+                    name = "ACME Checkout Test Tag 1",
                     status = EntityStatus("ACTIVE"),
                     version = "3",
                     configs = test_configs
-                )
+                ),
+                ConversionTagResponse(
+                    ad_account_id = self.test_ad_account_id,
+                    code_snippet = "<script type=text/javascript> [...]",
+                    enhanced_match_status = EnhancedMatchStatusType("NOT_VALIDATED"),
+                    id = self.test_conversion_tag_id,
+                    last_fired_time_ms = float(1599030000000),
+                    name = "ACME Checkout Test Tag 2",
+                    status = EntityStatus("ACTIVE"),
+                    version = "3",
+                    configs = test_configs
+                )   
             ]
         )
 
         conversion_tags = ConversionTag.get_all(
             ad_account_id = self.test_ad_account_id,
         )
-        conversion_tag = conversion_tags[0]
+
 
         get_mock.assert_not_called()
-
         assert conversion_tags
-        assert len(conversion_tags) == 1
-        assert conversion_tag
-        assert conversion_tag.ad_account_id == self.test_ad_account_id
-        assert conversion_tag.code_snippet == "<script type=text/javascript> [...]"
-        assert conversion_tag.enhanced_match_status == EnhancedMatchStatusType("VALIDATION_COMPLETE")
-        assert conversion_tag.id == self.test_conversion_tag_id
-        assert conversion_tag.last_fired_time_ms == float(1599030000000)
-        assert conversion_tag.name == "ACME Checkout Test Tag"
-        assert conversion_tag.status == EntityStatus("ACTIVE")
-        assert conversion_tag.version == "3"
-        assert conversion_tag.configs == test_configs
+        assert len(conversion_tags) == 2
+
+        conversion_tag_1 = conversion_tags[0]
+        assert conversion_tag_1
+        assert conversion_tag_1.ad_account_id == self.test_ad_account_id
+        assert conversion_tag_1.code_snippet == "<script type=text/javascript> [...]"
+        assert conversion_tag_1.enhanced_match_status == EnhancedMatchStatusType("VALIDATION_COMPLETE")
+        assert conversion_tag_1.id == self.test_conversion_tag_id
+        assert conversion_tag_1.last_fired_time_ms == float(1599030000000)
+        assert conversion_tag_1.name == "ACME Checkout Test Tag 1"
+        assert conversion_tag_1.status == EntityStatus("ACTIVE")
+        assert conversion_tag_1.version == "3"
+        assert conversion_tag_1.configs == test_configs
+
+        conversion_tag_2 = conversion_tags[1]
+        assert conversion_tag_2
+        assert conversion_tag_2.ad_account_id == self.test_ad_account_id
+        assert conversion_tag_2.code_snippet == "<script type=text/javascript> [...]"
+        assert conversion_tag_2.enhanced_match_status == EnhancedMatchStatusType("NOT_VALIDATED")
+        assert conversion_tag_2.id == self.test_conversion_tag_id
+        assert conversion_tag_2.last_fired_time_ms == float(1599030000000)
+        assert conversion_tag_2.name == "ACME Checkout Test Tag 2"
+        assert conversion_tag_2.status == EntityStatus("ACTIVE")
+        assert conversion_tag_2.version == "3"
+        assert conversion_tag_2.configs == test_configs
 
     @patch('pinterest.ads.conversion_tags.ConversionTagsApi.page_visit_conversion_tags_get')
     def test_get_page_visit_conversion_tag_event(self, get_page_visit_mock):
@@ -200,6 +224,12 @@ class TestConversionTagCreate(TestCase):
                     "conversion_tag_id": self.test_conversion_tag_id,
                     "ad_account_id": self.test_ad_account_id,
                     "created_time": 1564768710,
+                },
+                {
+                    "conversion_event": "UNKNOWN",
+                    "conversion_tag_id": self.test_conversion_tag_id,
+                    "ad_account_id": self.test_ad_account_id,
+                    "created_time": 1564768711,
                 }
             ],
             "bookmark": "test_bookmark",
@@ -213,10 +243,19 @@ class TestConversionTagCreate(TestCase):
         assert bookmark.get_bookmark_token() == "test_bookmark"
 
         assert conversion_tag_events
-        assert len(conversion_tag_events) == 1
-        assert type(conversion_tag_events[0]) == ConversionEventResponse
-        assert conversion_tag_events[0].ad_account_id == self.test_ad_account_id
-        assert conversion_tag_events[0].conversion_tag_id == self.test_conversion_tag_id
+        assert len(conversion_tag_events) == 2
+
+        conversion_tag_event_1 = conversion_tag_events[0]
+        assert type(conversion_tag_event_1) == ConversionEventResponse
+        assert conversion_tag_event_1.conversion_event == ConversionTagType("PAGE_LOAD")
+        assert conversion_tag_event_1.ad_account_id == self.test_ad_account_id
+        assert conversion_tag_event_1.conversion_tag_id == self.test_conversion_tag_id
+
+        conversion_tag_event_2 = conversion_tag_events[1]
+        assert type(conversion_tag_event_2) == ConversionEventResponse
+        assert conversion_tag_event_2.conversion_event == ConversionTagType("UNKNOWN")
+        assert conversion_tag_event_2.ad_account_id == self.test_ad_account_id
+        assert conversion_tag_event_2.conversion_tag_id == self.test_conversion_tag_id
 
     @patch('pinterest.ads.conversion_tags.ConversionTagsApi.ocpm_eligible_conversion_tags_get')
     def test_get_ocpm_eligible_conversion_tag_events(self, get_mock):

--- a/tests/src/pinterest/organic/test_pins.py
+++ b/tests/src/pinterest/organic/test_pins.py
@@ -11,7 +11,7 @@ from openapi_generated.pinterest_client.model.pin import Pin as GeneratedPin
 
 from pinterest.organic.pins import Pin
 
-class TestGetPin(TestCase):
+class TestPin(TestCase):
     """
     Test Pin model and its higher level functions
     """


### PR DESCRIPTION
1. Add missing attributes to `AdAccount` model
2. Update spend cap for campaigns based on server side validation
3. Add missing attributes to `Campaign` model 
4. Add missing attributes to `AdGroup` model and integration test utils
5. Use `PinCreate` from generated client in `Pin` model for pin creation
6. Update .gitignore with log file
7. Fix conversion tag and event model and tests
8. Fix tests for `Pin` model
9. Change test constants for `Board` model integration tests
10. Change `Board` tests to generate a random board name to avoid collision 
11. Clean all organic data before running integration tests