### PR TITLE
Pass client to base method from entity `create` `@classmethod`

### DIFF
--- a/pinterest/ads/ad_accounts.py
+++ b/pinterest/ads/ad_accounts.py
@@ -140,6 +140,7 @@ class AdAccount(PinterestBaseModel):
             },
             api=AdAccountsApi,
             create_fn=AdAccountsApi.ad_accounts_create,
+            client=cls._get_client(client),
         )
         return cls(ad_account_id=response.id, client=cls._get_client(client))
 

--- a/pinterest/ads/ad_groups.py
+++ b/pinterest/ads/ad_groups.py
@@ -331,7 +331,8 @@ class AdGroup(PinterestBaseModel):
             },
             api=AdGroupsApi,
             create_fn=AdGroupsApi.ad_groups_create,
-            map_fn=lambda obj: obj.items[0].data
+            map_fn=lambda obj: obj.items[0].data,
+            client=cls._get_client(client),
         )
         return cls(
             ad_account_id=response.ad_account_id,

--- a/pinterest/ads/ads.py
+++ b/pinterest/ads/ads.py
@@ -305,7 +305,8 @@ class Ad(PinterestBaseModel):
             },
             api=AdsApi,
             create_fn=AdsApi.ads_create,
-            map_fn=lambda obj: obj.items[0].data
+            map_fn=lambda obj: obj.items[0].data,
+            client=cls._get_client(client),
         )
         return cls(
             ad_account_id=response.ad_account_id,

--- a/pinterest/ads/audiences.py
+++ b/pinterest/ads/audiences.py
@@ -178,7 +178,8 @@ class Audience(PinterestBaseModel):
                 ),
             },
             api=AudiencesApi,
-            create_fn=AudiencesApi.audiences_create
+            create_fn=AudiencesApi.audiences_create,
+            client=cls._get_client(client),
         )
 
         return cls(

--- a/pinterest/ads/campaigns.py
+++ b/pinterest/ads/campaigns.py
@@ -289,7 +289,8 @@ class Campaign(PinterestBaseModel):
             },
             api=CampaignsApi,
             create_fn=CampaignsApi.campaigns_create,
-            map_fn=lambda obj: obj.items[0].data
+            map_fn=lambda obj: obj.items[0].data,
+            client=cls._get_client(client),
         )
 
         return cls(

--- a/pinterest/ads/conversion_tags.py
+++ b/pinterest/ads/conversion_tags.py
@@ -187,6 +187,7 @@ class ConversionTag(PinterestBaseModel):
             api = ConversionTagsApi,
             create_fn = ConversionTagsApi.conversion_tags_create,
             map_fn = lambda obj : obj,
+            client=cls._get_client(client),
         )
 
 

--- a/pinterest/ads/customer_lists.py
+++ b/pinterest/ads/customer_lists.py
@@ -160,6 +160,7 @@ class CustomerList(PinterestBaseModel):
             },
             api=CustomerListsApi,
             create_fn=CustomerListsApi.customer_lists_create,
+            client=cls._get_client(client),
         )
 
         return cls(

--- a/pinterest/ads/keywords.py
+++ b/pinterest/ads/keywords.py
@@ -142,6 +142,7 @@ class Keyword(PinterestBaseModel):
             api=KeywordsApi,
             create_fn=KeywordsApi.keywords_create,
             map_fn=map_fn,
+            client=cls._get_client(client),
         )
 
         return cls(


### PR DESCRIPTION
This PR fixes entity create methods as previously users were unable to pass SDK clients from the class to the base model create method.