### PR TITLE
Fix ad group and conversion events integration tests

### DIFF
--- a/integration_tests/ads/test_ad_groups.py
+++ b/integration_tests/ads/test_ad_groups.py
@@ -64,7 +64,7 @@ class TestUpdateAdGroup(BaseTestCase):
 
         new_name = "SDK_AD_GROUP_NEW_NAME"
         new_spec = {
-                "GENDER": ["MALE"]
+                "GENDER": ["male"]
         }
 
         ad_group.update_fields(

--- a/integration_tests/ads/test_conversion_events.py
+++ b/integration_tests/ads/test_conversion_events.py
@@ -51,11 +51,9 @@ class TestSendConversionEvent(BaseTestCase):
 
         assert response.events[0].status == "processed"
         assert response.events[0].error_message == ""
-        assert response.events[0].warning_message == ""
 
         assert response.events[1].status == "processed"
         assert response.events[1].error_message == ""
-        assert response.events[1].warning_message == ""
 
     def test_send_conversion_fail(self):
         """
@@ -90,8 +88,8 @@ class TestSendConversionEvent(BaseTestCase):
 
         assert response
         assert response.num_events_received == 2
-        assert response.num_events_processed == 2
+        assert response.num_events_processed == 0
         assert len(response.events) == 2
 
-        assert response.events[0].warning_message #warning returned
-        assert response.events[1].warning_message #warning returned
+        assert 'hashed format' in response.events[0].error_message
+        assert 'hashed format' in response.events[0].error_message

--- a/tests/src/pinterest/ads/test_ad_groups.py
+++ b/tests/src/pinterest/ads/test_ad_groups.py
@@ -102,7 +102,7 @@ class TestAdGroup(TestCase):
         update_mock.__name__ = "ad_groups_update"
         new_name = "SDK_AD_GROUP_NEW_NAME"
         new_spec = {
-                "GENDER": ["MALE"]
+                "GENDER": ["male"]
         }
 
         get_mock.return_value = AdGroupResponse(


### PR DESCRIPTION
- Change ad group targeting from `MALE` to `male` due to spec changes
- Change conversion event response due to spec changes and assert error message when request fails