### PR TITLE
Fix to incorrect error message when wrong refresh token is passed in

### DIFF
--- a/integration_tests/client/test_client.py
+++ b/integration_tests/client/test_client.py
@@ -12,6 +12,7 @@ from openapi_generated.pinterest_client.exceptions import UnauthorizedException
 from pinterest.organic.boards import Board
 from pinterest.client import PinterestSDKClient
 from integration_tests.base_test import BaseTestCase
+from pinterest.utils.error_handling import SdkException
 
 
 class ClientTest(BaseTestCase):
@@ -55,6 +56,18 @@ class ClientTest(BaseTestCase):
         )
         PinterestSDKClient.set_default_access_token(access_token=good_access_token)
         self.assertIsNotNone(Board.get_all())
+
+    def test_bad_refresh_token(self):
+        refresh_token = 'refresh_token'
+        app_id = '12345'
+        app_secret = '123456asdfg'
+        with self.assertRaises(SdkException):
+            PinterestSDKClient._get_access_token(
+                refresh_token=refresh_token,
+                app_id=app_id,
+                app_secret=app_secret
+            )
+
 
 
 

--- a/pinterest/utils/refresh_access_token.py
+++ b/pinterest/utils/refresh_access_token.py
@@ -50,7 +50,8 @@ def get_new_access_token(
             body="Authentication error. " +
             "Kindly check if the following variables are correct: [PINTEREST_ACCESS_TOKEN] or " +
             "[PINTEREST_APP_ID, PINTEREST_APP_SECRET, PINTEREST_REFRESH_ACCESS_TOKEN]. " +
-            f"Response from server: {response.body}"
+            f"Response from server: {response.data}",
+            http_resp=response
             )
     if response.status != 200:
         raise SdkException(http_resp=response)

--- a/tests/src/pinterest/client/client_test.py
+++ b/tests/src/pinterest/client/client_test.py
@@ -75,13 +75,10 @@ class ClientTest(unittest.TestCase):
         self.assertNotEqual(refresh_token, PINTEREST_REFRESH_ACCESS_TOKEN)
         self.assertNotEqual(app_id, PINTEREST_APP_ID)
         self.assertNotEqual(app_secret, PINTEREST_APP_SECRET)
-        
-        try:
+        with self.assertRaises(SdkException):
             PinterestSDKClient._get_access_token(
                 refresh_token=refresh_token,
                 app_id=app_id,
                 app_secret=app_secret
             )
-            self.assertTrue(False)
-        except SdkException as e:
-            self.assertTrue(True)
+

--- a/tests/src/pinterest/client/client_test.py
+++ b/tests/src/pinterest/client/client_test.py
@@ -3,6 +3,7 @@ from unittest import mock
 from unittest.mock import patch
 import unittest
 import subprocess
+from pinterest.utils.sdk_exceptions import SdkException
 
 from pinterest.client import PinterestSDKClient
 
@@ -52,3 +53,35 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(refresh_token, PINTEREST_REFRESH_ACCESS_TOKEN)
         self.assertEqual(app_id, PINTEREST_APP_ID)
         self.assertEqual(app_secret, PINTEREST_APP_SECRET)
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "PINTEREST_APP_ID": "test_app_id",
+            "PINTEREST_APP_SECRET": "test_app_secret",
+         },
+        clear=True
+    )
+    @patch('dotenv.load_dotenv')
+    def test_set_bad_refresh_token(self, load_dotenv_mock):
+        load_dotenv_mock.return_value = None
+        refresh_token = 'refresh_token'
+        app_id = '12345'
+        app_secret = '123456asdfg'
+
+        from pinterest.config import PINTEREST_REFRESH_ACCESS_TOKEN
+        from pinterest.config import PINTEREST_APP_ID
+        from pinterest.config import PINTEREST_APP_SECRET
+        self.assertNotEqual(refresh_token, PINTEREST_REFRESH_ACCESS_TOKEN)
+        self.assertNotEqual(app_id, PINTEREST_APP_ID)
+        self.assertNotEqual(app_secret, PINTEREST_APP_SECRET)
+        
+        try:
+            PinterestSDKClient._get_access_token(
+                refresh_token=refresh_token,
+                app_id=app_id,
+                app_secret=app_secret
+            )
+            self.assertTrue(False)
+        except SdkException as e:
+            self.assertTrue(True)


### PR DESCRIPTION
Fix to incorrect error message when wrong refresh token is passed in. In reference to this [bug](https://github.com/pinterest/pinterest-python-sdk/issues/114)

Passing Integration Tests:
<img width="713" alt="Screenshot 2023-11-29 at 5 26 58 PM" src="https://github.com/pinterest/pinterest-python-sdk/assets/101220391/7c30f867-4810-4afb-816f-06d2bb8fe34d">
