### PR TITLE
Fix bug in set_lifetime_budget

### DIFF
--- a/pinterest/ads/campaigns.py
+++ b/pinterest/ads/campaigns.py
@@ -376,11 +376,11 @@ class Campaign(PinterestBaseModel):
         """
         api_response = self._generated_api.campaigns_update(
             ad_account_id=self._ad_account_id,
-            campaign_update_request=CampaignUpdateRequest(
+            campaign_update_request=[CampaignUpdateRequest(
                 id=self._id,
                 ad_account_id=self._ad_account_id,
                 lifetime_spend_cap=new_spend_cap
-                )
+                )]
             )
         verify_api_response(api_response)
 


### PR DESCRIPTION
campaign_update_request should be a list instead of a single campaign request

Reported in 
https://github.com/pinterest/pinterest-python-sdk/issues/139