### PR TITLE
Allow future versions of dotenv to be installed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Pinterest-Generated-Client==0.1.9
 python-dateutil==2.8.2
 six==1.16.0
 urllib3==1.26.12
-python-dotenv==0.20.0
+python-dotenv>=0.20.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ _IS_TEST_BUILD = os.environ.get("IS_TEST_BUILD", 0)
 REQUIRES = [
   "urllib3==1.26.12",
   "python-dateutil",
-  "python-dotenv==0.20.0",
+  "python-dotenv>=0.20.0",
   "six==1.16.0",
   "Pinterest-Generated-Client==0.1.9"
 ]


### PR DESCRIPTION
Instead of specifying 0.20.0, the client can work with any future version.
Tested with the latest version - 1.0.1

Requested feature/bug in https://github.com/pinterest/pinterest-python-sdk/issues/138

Run integration test locally: 
<img width="447" alt="image" src="https://github.com/user-attachments/assets/f7b538ab-4832-451d-b668-573f66691848" />

