### PR TITLE
excluding client from kwargs

### DIFF
--- a/pinterest/ads/ad_groups.py
+++ b/pinterest/ads/ad_groups.py
@@ -350,7 +350,7 @@ class AdGroup(PinterestBaseModel):
             client=cls._get_client(client)
         )
 
-    def update_fields(self, **kwargs) -> bool:
+    def update_fields(self, client: PinterestSDKClient = None, **kwargs) -> bool:
         """
         Update adgroup fields using any arguments
 
@@ -376,6 +376,7 @@ class AdGroup(PinterestBaseModel):
             },
             api=AdGroupsApi,
             update_fn=AdGroupsApi.ad_groups_update,
+            client=client,
             **kwargs
         )
 

--- a/pinterest/ads/ads.py
+++ b/pinterest/ads/ads.py
@@ -417,7 +417,7 @@ class Ad(PinterestBaseModel):
             **kwargs
         )
 
-    def update_fields(self, **kwargs) -> bool:
+    def update_fields(self, client: PinterestSDKClient = None, **kwargs) -> bool:
         """
         Update Ad fields suing any arguments
 
@@ -440,5 +440,6 @@ class Ad(PinterestBaseModel):
             },
             api=AdsApi,
             update_fn=AdsApi.ads_update,
+            client=client,
             **kwargs
         )

--- a/pinterest/ads/audiences.py
+++ b/pinterest/ads/audiences.py
@@ -250,7 +250,7 @@ class Audience(PinterestBaseModel):
             **kwargs
         )
 
-    def update_fields(self, **kwargs):
+    def update_fields(self, client: PinterestSDKClient = None, **kwargs):
         """
         Update audience fields
 
@@ -271,5 +271,6 @@ class Audience(PinterestBaseModel):
             },
             api=AudiencesApi,
             update_fn=AudiencesApi.audiences_update,
+            client=client,
             **kwargs
         )

--- a/pinterest/ads/campaigns.py
+++ b/pinterest/ads/campaigns.py
@@ -485,7 +485,7 @@ class Campaign(PinterestBaseModel):
         """
         return self._change_status('ARCHIVED')
 
-    def update_fields(self, **kwargs) -> bool:
+    def update_fields(self, client: PinterestSDKClient = None, **kwargs) -> bool:
         """
         Update the campaign fields using any attributes.
 
@@ -508,6 +508,7 @@ class Campaign(PinterestBaseModel):
             },
             api=CampaignsApi,
             update_fn=CampaignsApi.campaigns_update,
+            client=client,
             **kwargs
         )
 


### PR DESCRIPTION
## Summary
Currently, if a user does not have credentials loaded into their environment or a config file on import, they are unable to update the fields of an ad, ad group, campaign, or audience. This is because it is impossible to pass a custom Pinterest client object into the `update_fields` function for each of those objects.

The root of this problem is within the `update_fields` function, where `kwargs` is passed into `self._update` and into `self._update` via the `params` input. When `client` is passed into the `update_fields` function, it is treated as a `kwarg` and is therefor passed into `self._update` twice. As `client` should not be passed into `self._update` via `params`, by explicitly adding an argument for `client`, the variable is excluded from `kwargs` and the function performs as expected.

## Changes
- In `ad_groups.py`, `ads.py`, `audiences.py`, and `campaigns.py`, `client` was added as an argument with `None` as the default value for the `update_fields` function. That argument is then explicitly passed into `self._update`

## Testing
- This was tested locally, and updates were successfully made to platform