### PR TITLE
chore(deps): bumps `urllib3` to 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pinterest-Generated-Client==0.1.10
 python-dateutil==2.8.2
 six==1.16.0
-urllib3>=1.26.12
+urllib3==2.7.0
 python-dotenv>=0.20.0


### PR DESCRIPTION
Issue: https://github.com/pinterest/pinterest-python-sdk/issues/172

urllib3's [streaming API](https://urllib3.readthedocs.io/en/2.6.2/advanced-usage.html#streaming-and-i-o) is designed for the efficient handling of large HTTP responses by reading the content in chunks, rather than loading the entire response body into memory at once.

urllib3 can perform decoding or decompression based on the HTTP Content-Encoding header (e.g., gzip, deflate, br, or zstd). When using the streaming API, the library decompresses only the necessary bytes, enabling partial content consumption.

However, for HTTP redirect responses, the library would read the entire response body to drain the connection and decompress the content unnecessarily. This decompression occurred even before any read methods were called, and configured read limits did not restrict the amount of decompressed data. As a result, there was no safeguard against decompression bombs. A malicious server could exploit this to trigger excessive resource consumption on the client (high CPU usage and large memory allocations for decompressed data; CWE-409).

## Affected usages
Applications and libraries using urllib3 version 2.6.2 and earlier to stream content from untrusted sources by setting preload_content=False when they do not disable redirects.

## Remediation
Upgrade to at least urllib3 v2.6.3 in which the library does not decode content of redirect responses when preload_content=False.

If upgrading is not immediately possible, disable [redirects](https://urllib3.readthedocs.io/en/2.6.2/user-guide.html#retrying-requests) by setting redirect=False for requests to untrusted source.