### PR TITLE
chore: bump Pinterest-Generated-Client to 0.1.12

### DIFF
--- a/integration_tests/ads/test_ad_groups.py
+++ b/integration_tests/ads/test_ad_groups.py
@@ -7,6 +7,8 @@ from integration_tests.config import DEFAULT_AD_ACCOUNT_ID
 
 from pinterest.ads.ad_groups import AdGroup
 
+from openapi_generated.pinterest_client.exceptions import ApiException
+
 
 class TestCreateAdGroup(BaseTestCase):
     '''
@@ -103,7 +105,9 @@ class TestUpdateAdGroup(BaseTestCase):
             tracking_urls=new_tracking_url
         )
 
-        with self.assertRaises(AssertionError):
+        # The API now rejects unsupported tracking-URL event types with HTTP 400,
+        # which the generated client raises as ApiException.
+        with self.assertRaises(ApiException):
             ad_group.update_fields(**update_argument)
 
 

--- a/integration_tests/ads/test_campaigns.py
+++ b/integration_tests/ads/test_campaigns.py
@@ -31,6 +31,7 @@ class TestCreateCampaign(BaseTestCase):
             name="SDK Test Campaign",
             objective_type="AWARENESS",
             daily_spend_cap=10000000,
+            is_campaign_budget_optimization=True,
         )
 
         assert campaign
@@ -43,11 +44,15 @@ class TestCreateCampaign(BaseTestCase):
         """
         Verify a new Campaign response failure and catching exceptions
         """
+        # This ad account requires Campaign Budget Optimization, so CBO must be on;
+        # with CBO on and no spend cap the API reports the missing-budget error 2384
+        # (CBO campaigns need [lifetime_spend_cap and end_time] or daily_spend_cap).
         campaign_arguments = dict(
             client=self.test_client,
             ad_account_id=DEFAULT_AD_ACCOUNT_ID,
             name="SDK Test Campaign",
             objective_type="AWARENESS",
+            is_campaign_budget_optimization=True,
         )
 
         self.assertRaisesRegex(

--- a/integration_tests/ads/test_keywords.py
+++ b/integration_tests/ads/test_keywords.py
@@ -8,8 +8,8 @@ from integration_tests.base_test import BaseTestCase
 from integration_tests.config import DEFAULT_AD_ACCOUNT_ID
 
 from pinterest.ads.keywords import Keyword
-from pinterest.utils.sdk_exceptions import SdkException
 
+from openapi_generated.pinterest_client.exceptions import ApiException
 from openapi_generated.pinterest_client.model.match_type_response import MatchTypeResponse
 
 
@@ -44,7 +44,9 @@ class TestCreateKeyword(BaseTestCase):
             value="string",
         )
 
-        with self.assertRaises(SdkException):
+        # Without a match_type the API rejects the request outright with HTTP 400
+        # (match_type is not nullable), which the generated client raises as ApiException.
+        with self.assertRaises(ApiException):
             Keyword.create(**keyword_arguments)
 
 

--- a/integration_tests/utils/ads_utils.py
+++ b/integration_tests/utils/ads_utils.py
@@ -109,6 +109,9 @@ class CampaignUtils:
             name="SDK Test Campaign",
             objective_type="AWARENESS",
             daily_spend_cap=10000000,
+            # This ad account requires Campaign Budget Optimization (ad-group level
+            # budgets are not allowed), so budgets must be set at the campaign level.
+            is_campaign_budget_optimization=True,
         )
         self.campaign_id = self.campaign._id
 
@@ -125,6 +128,9 @@ class CampaignUtils:
             name="SDK Test Campaign",
             objective_type="AWARENESS",
             daily_spend_cap=10000000,
+            # This ad account requires Campaign Budget Optimization (ad-group level
+            # budgets are not allowed), so budgets must be set at the campaign level.
+            is_campaign_budget_optimization=True,
         )
 
     def create_new_campaign(self, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Pinterest-Generated-Client==0.1.10
+Pinterest-Generated-Client==0.1.12
 python-dateutil==2.8.2
 six==1.16.0
 urllib3>=1.26.12


### PR DESCRIPTION
## Summary

### Problem (Why)

Integration tests were still pinned to `Pinterest-Generated-Client==0.1.10`. After moving to 0.1.12, two things no longer match live Ads API behavior:

1. Some invalid requests that the SDK previously wrapped as `SdkException` or failed as `AssertionError` now fail at the HTTP layer. The generated client raises `ApiException` (HTTP 400) instead.
2. The test ad account requires Campaign Budget Optimization, so campaign creates without `is_campaign_budget_optimization=True` fail before the cases under test can run.

### Solution (What + How)

Bump `Pinterest-Generated-Client` from 0.1.10 to 0.1.12 in `requirements.txt`, then align ads integration tests with the new client and account constraints:

- Expect `ApiException` for unsupported ad-group tracking-URL event types and for keyword create without `match_type`.
- Pass `is_campaign_budget_optimization=True` on campaign create (including `CampaignUtils` helpers) so CBO-required accounts succeed, and so the missing-budget failure case still hits API error 2384.

## Test Plan

- [x] Install deps with the new client pin (`Pinterest-Generated-Client==0.1.12`).
- [x] Run ads integration tests, especially:
  - `integration_tests/ads/test_campaigns.py`
  - `integration_tests/ads/test_ad_groups.py`
  - `integration_tests/ads/test_keywords.py`
- [x] Confirm campaign create succeeds with CBO enabled and a daily spend cap.
- [x] Confirm the campaign missing-budget case still fails with error 2384.
- [x] Confirm ad-group tracking-URL and keyword-without-`match_type` cases fail with `ApiException` rather than `AssertionError` / `SdkException`.